### PR TITLE
fix: [BUG-4863]Added border in high contrast mode and also added media query for 20…

### DIFF
--- a/App/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/App/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -85,7 +85,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
                 { sendQuestionDisabled ? 
                     <SendRegular className={styles.questionInputSendButtonDisabled}/>
                     :
-                    <img src={Send} className={styles.questionInputSendButton}/>
+                    <img src={Send} className={styles.questionInputSendButton}  alt="Send"/>
                 }
             </div>
             <div className={styles.questionInputBottomBorder} />

--- a/App/frontend/src/pages/Homepage/Homepage.module.css
+++ b/App/frontend/src/pages/Homepage/Homepage.module.css
@@ -55,8 +55,8 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-
   gap: 20px;
+  margin-bottom: 3%;
 }
 
 .feature {
@@ -84,4 +84,76 @@
 .featureIcon {
   min-width: 48;
   min-height: 48;
+}
+
+/* Styles for 1280p resolution at 200% zoom */
+@media screen and (max-width: 640px) {
+  .main {
+    width: 65% !important;
+    gap:20px !important;
+  }
+
+  .header{
+    margin-bottom: 0 !important;
+  }
+
+  .appIcon{
+    width: 25% !important;
+    height: 50px !important;
+    margin-top: 3% !important;
+  }
+
+  .container{
+    margin-bottom: 3% !important;
+  }
+
+  p {
+    font-size: 0.6rem !important;
+  }
+
+  .features {
+    width: 119% !important;
+    gap: 7px !important;
+  }
+}
+
+/* Styles for 1280p resolution at 400% zoom */
+@media screen and (max-width: 320px) {
+
+  h1{
+    font-size: 1rem;
+  }
+  .main {
+    width: 65% !important;
+    gap:20px !important;
+  }
+
+  .header{
+    margin-bottom: 0 !important;
+  }
+
+  .appIcon{
+    width: 25% !important;
+    height: 50px !important;
+    margin-top: 3% !important;
+  }
+
+  .container{
+    width: 75% !important;
+    margin-bottom: 3% !important;
+  }
+
+  p {
+    font-size: 0.6rem !important;
+  }
+
+  .features {
+    width: 100% !important;
+    gap: 7px !important;
+  }
+
+  svg{
+    width: .5rem !important;
+    height: .5rem !important;
+  }
 }

--- a/App/frontend/src/pages/Homepage/Homepage.module.css
+++ b/App/frontend/src/pages/Homepage/Homepage.module.css
@@ -13,17 +13,17 @@
   justify-content: center;
   
   width: 40%;
-  gap: 40px;
+  gap: 8px;
 }
 
 .header {
-  margin-bottom: 20px;
+  margin-bottom: 2px;
   text-align: center;
 }
 
 .appIcon {
-  width: 100px;
-  height: 100px;
+  width: 77px;
+  height: 77px;
 }
 
 .gradientText {

--- a/App/frontend/src/pages/Homepage/Homepage.tsx
+++ b/App/frontend/src/pages/Homepage/Homepage.tsx
@@ -29,8 +29,8 @@ const Homepage: React.FC = () => {
             icon={
               <NewsRegular
                 style={{
-                  minWidth: 48,
-                  minHeight: 48
+                  minWidth: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
+                  minHeight: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
                 }}
               />
             }
@@ -42,8 +42,8 @@ const Homepage: React.FC = () => {
             icon={
               <BookRegular
                 style={{
-                  minWidth: 48,
-                  minHeight: 48
+                  minWidth: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
+                  minHeight: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
                 }}
               />
             }
@@ -55,8 +55,8 @@ const Homepage: React.FC = () => {
             icon={
               <NotepadRegular
                 style={{
-                  minWidth: 48,
-                  minHeight: 48
+                  minWidth: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
+                  minHeight: window.matchMedia('(max-width:320px)').matches ? "1rem" : 48,
                 }}
               />
             }

--- a/App/frontend/src/pages/chat/Chat.module.css
+++ b/App/frontend/src/pages/chat/Chat.module.css
@@ -169,7 +169,7 @@
     position: absolute;
     width: 40px;
     height: 40px;
-    left: 7px;
+    left: 0%;
     top: 66px;
     color: #FFFFFF;
     border-radius: 4px;

--- a/App/frontend/src/pages/layout/Layout.module.css
+++ b/App/frontend/src/pages/layout/Layout.module.css
@@ -1,9 +1,7 @@
 .layout {
     flex: 1 1 100%;
-
     width: 100%;
     height: 100%;
-
     display: flex;
     flex-direction: row;
 
@@ -28,4 +26,27 @@
 .headerIcon {
     height: 24px;
     width: 24px;
+}
+
+/* Styles for 1280p resolution at 200% zoom */
+@media screen and (min-width: 1280px) {
+    .layout {
+        height: unset !important;
+        width: 100% !important;
+    }
+}
+
+@media screen and (-ms-high-contrast: active), (forced-colors: active) {
+    .layout{
+        border: 2px solid WindowText;padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
+}
+
+/* Styles for 1280p resolution at 400% zoom */
+@media screen and (max-width: 320px) {
+    .layout {
+        width: 250% !important;
+    }
 }

--- a/App/frontend/src/pages/layout/Layout.module.css
+++ b/App/frontend/src/pages/layout/Layout.module.css
@@ -1,7 +1,7 @@
 .layout {
     flex: 1 1 100%;
-    width: 100%;
-    height: 100%;
+    /* width: 100%;
+    height: 100%; */
     display: flex;
     flex-direction: row;
 
@@ -31,8 +31,8 @@
 /* Styles for 1280p resolution at 200% zoom */
 @media screen and (min-width: 1280px) {
     .layout {
-        height: unset !important;
-        width: 100% !important;
+        width: auto !important;
+        height: auto !important;
     }
 }
 

--- a/App/frontend/src/pages/layout/Layout.module.css
+++ b/App/frontend/src/pages/layout/Layout.module.css
@@ -1,7 +1,5 @@
 .layout {
     flex: 1 1 100%;
-    /* width: 100%;
-    height: 100%; */
     display: flex;
     flex-direction: row;
 

--- a/App/frontend/src/pages/layout/Layout.tsx
+++ b/App/frontend/src/pages/layout/Layout.tsx
@@ -40,8 +40,7 @@ const Layout = (): JSX.Element => {
 
   return (
         <Stack style={{
-          height: '100vh',
-          width: '100vw',
+          width: '100%',
           backgroundColor: '#EDEBE9',
           padding: '1rem'
         }}>
@@ -53,6 +52,7 @@ const Layout = (): JSX.Element => {
                     src={Icon}
                     className={styles.headerIcon}
                     aria-hidden="true"
+                    alt="App Icon"
                 />
                 <Link to="/" className={styles.headerTitleContainer}
                     onClick={() => {

--- a/App/frontend/src/pages/layout/Layout.tsx
+++ b/App/frontend/src/pages/layout/Layout.tsx
@@ -40,7 +40,8 @@ const Layout = (): JSX.Element => {
 
   return (
         <Stack style={{
-          width: '100%',
+          height: '100vh',
+          width: '100vw',
           backgroundColor: '#EDEBE9',
           padding: '1rem'
         }}>


### PR DESCRIPTION
Bug: https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/4863/
**Below Bugs are fixed**
**1. Images**

Open BYOAI URL.
Open inspect.
Alternative text for Images.

Expected result: Need to add an alternative text for image.


**2. High Contrast modes**

Open BYOAI URL.
Go to system setting ->Accessibility->Contrast themes->select aquatic in drop down-> apply.
Go to BYOAI URL, you can find the screen, outer border is not visible

Expected result: By providing borders to the fields.



**3. Resizing: Text in the page should be adaptable to resizing up to 200% zoom in 1280p without overlap.**

Open BYOAI URL.
Go to system setting ->System->Display resolution->select 1280P in drop down-> apply.
Go to BYOAI URL, zoom it to 200%, you can find the screen the content overlapping, and conversation area is not visible.

Expected result: Resize of the content without overlap.


**4. Resizing: There should be no horizontal scroll bar for up to 400% zoom in 1280p**

Open BYOAI URL.
Go to system setting ->System->Display resolution->select 1280P in drop down-> apply.
Go to BYOAI URL, zoom it to 400%, you can find the screen the content overlapping, and there is a horizontal scroll bar.

Expected result: Resize of the content without overlap and no horizontal bar.


