### PR TITLE
fix: [Bug-4865] Added css for highcContrast modes

### DIFF
--- a/App/frontend/src/components/QuestionInput/QuestionInput.module.css
+++ b/App/frontend/src/components/QuestionInput/QuestionInput.module.css
@@ -54,3 +54,11 @@
     width: 27px;
     height: 30px;
 }
+
+@media screen and (-ms-high-contrast: active), (forced-colors: active) {
+    .questionInputContainer{
+        border: 2px solid WindowText;padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
+}

--- a/App/frontend/src/components/SidebarView/SidebarView.module.css
+++ b/App/frontend/src/components/SidebarView/SidebarView.module.css
@@ -60,3 +60,20 @@
     -moz-user-select: none; /* Firefox 2+ */
     -ms-user-select: none; /* IE 10+ */
 }
+
+.articlesFav{
+    width: 20rem;
+    background-color: #FAFAFA;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    padding-top: 3rem;
+}
+
+@media screen and (-ms-high-contrast: active), (forced-colors: active) {
+    .articlesFav{
+         border: 2px solid WindowText;padding: 10px;
+         background-color: Window;
+         color: WindowText;
+     }
+ }

--- a/App/frontend/src/components/SidebarView/SidebarView.tsx
+++ b/App/frontend/src/components/SidebarView/SidebarView.tsx
@@ -76,14 +76,7 @@ export const SidebarView = (): JSX.Element => {
                 {
                     isExpanded
                       ? (
-                        <Stack style={{
-                          width: '20rem',
-                          backgroundColor: '#FAFAFA',
-                          flexDirection: 'column',
-                          justifyContent: 'flex-start',
-                          alignItems: 'center',
-                          paddingTop: '3rem'
-                        }}>
+                        <Stack className={styles.articlesFav}>
                             {
                               sidebarLoaded
                                 ? (selectedViewComponent)

--- a/App/frontend/src/pages/chat/Chat.module.css
+++ b/App/frontend/src/pages/chat/Chat.module.css
@@ -324,3 +324,11 @@ a {
     text-decoration: underline;
     cursor: pointer;
 }
+
+@media screen and (-ms-high-contrast: active), (forced-colors: active) {
+   .clearChatBroomNoCosmos{
+        border: 2px solid WindowText;padding: 10px;
+        background-color: Window;
+        color: WindowText;
+    }
+}


### PR DESCRIPTION
Bug : https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/4865

1. High Contrast modes

Open BYOAI URL.
Go to system setting ->Accessibility->Contrast themes->select aquatic in drop down-> apply.
Go to BYOAI URL, you can find the screen, outer border is not visible

Expected result: By providing borders to the fields.

![image](https://github.com/microsoft/Build-your-own-AI-Assistant-Solution-Accelerator/assets/168007985/daa6b162-c716-4f24-84ce-5f6f87fcd4f6)

![image](https://github.com/microsoft/Build-your-own-AI-Assistant-Solution-Accelerator/assets/168007985/0221fcbe-8aaa-489a-9040-07088188407e)
