### PR TITLE
fix: [BUG-4424] Added accessibility UI changes for articles

### DIFF
--- a/App/frontend/src/components/SidebarView/ArticleView/ArticleView.tsx
+++ b/App/frontend/src/components/SidebarView/ArticleView/ArticleView.tsx
@@ -38,11 +38,12 @@ export const ArticleView = () => {
           marginTop: "0",
         }}
       >
-       
-        <Text variant="xLarge" style={{ alignSelf: "flex-start", marginTop: "0" }}>
+
+        <h2 style={{ alignSelf: "flex-start", marginTop: "0" ,fontWeight: '500'}}>
           Favorites
-        </Text>
+        </h2>
         <Button
+          title="close"
           style={{ border: "none", alignSelf: "flex-start", marginTop: "0" }}
           icon={<Dismiss24Regular />}
           onClick={() => {

--- a/App/frontend/src/components/SidebarView/SidebarView.module.css
+++ b/App/frontend/src/components/SidebarView/SidebarView.module.css
@@ -32,7 +32,7 @@
 }
 
 .sidebarNavigationButton:active{
-    color:#797775 !important;
+    color:#72716f  !important;
 } 
 
 .mt1 {

--- a/App/frontend/src/pages/chat/Chat.tsx
+++ b/App/frontend/src/pages/chat/Chat.tsx
@@ -334,16 +334,16 @@ const Chat = ({ chatType }: Props) => {
     <div className={styles.container} role="main">
         <Stack horizontal className={styles.chatRoot}>
             <div className={styles.chatContainer}>
-                <Text variant="xLarge"
+                <h2
                     style={{
-                      color: '#797775',
+                      color: '#72716f',
                       marginLeft: '15px',
                       marginTop: '25px',
                       alignSelf: 'start'
                     }}
                 >
                     {title}
-                </Text>
+                </h2>
             <div className={styles.chatMessageStream} style={{ marginBottom: isLoading ? '40px' : '0px' }} role="log">
                 {messages.map((answer, index) => (
                 <>

--- a/App/frontend/src/pages/layout/Layout.tsx
+++ b/App/frontend/src/pages/layout/Layout.tsx
@@ -63,7 +63,7 @@ const Layout = (): JSX.Element => {
                       }
                     }}
                 >
-                    <Text as="h1" className={classes.headerTitle}>Grant Writer</Text>
+                    <h1 className={classes.headerTitle}>Grant Writer</h1>
                 </Link>
             </Stack>
 


### PR DESCRIPTION
Bug:  https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/4424/

**1. Automated check: color-contrast**

Title: WCAG 1.4.3: Elements must meet minimum color contrast ratio thresholds (.css-113)
Tags: Accessibility, WCAG 1.4.3, color-contrast

Issue: Elements must meet minimum color contrast ratio thresholds (color-contrast - https://accessibilityinsights.io/info-examples/web/color-contrast)

Target application: Grant Writer - https://pbn-app-service.azurewebsites.net/

Element path: ._chatContainer_196nq_18 > .css-113

Snippet: <span class="css-113" style="color: rgb(121, 119, 117); margin-left: 15px; margin-top: 25px; align-self: start;">Explore scientific journals</span>

Fix the following:
Element has insufficient color contrast of 4.45 (foreground color: #797775, background color: #ffffff, font size: 15.0pt (20px), font weight: normal). Expected contrast ratio of 4.5:1Element has insufficient color contrast of 4.45 (foreground color: #797775, background color: #ffffff, font size: 15.0pt (20px), font weight: normal). Expected contrast ratio of 4.5:1

Use foreground color: #72716f and the original background color: #ffffff to meet a contrast ratio of 4.88:1.


**2. Heading**

Open BYOAI URL
Click on articles
Here "Explore scientific journals" and Favorites are not marked as heading

Expected result: Need to mark as heading

