### PR TITLE
fix: added citation panel border

### DIFF
--- a/App/frontend/src/pages/chat/Chat.module.css
+++ b/App/frontend/src/pages/chat/Chat.module.css
@@ -327,7 +327,7 @@ a {
 
 /* high constrat */
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
-    .clearChatBroomNoCosmos, .chatMessageStream, .chatMessageUserMessage{
+    .clearChatBroomNoCosmos, .chatMessageStream, .chatMessageUserMessage, .citationPanel{
         border: 2px solid WindowText;padding: 10px;
         background-color: Window;
         color: WindowText;


### PR DESCRIPTION
Bug : https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/4443

High Contrast modes
Open BYOAI URL.
Go to system setting ->Accessibility->Contrast themes->select aquatic in drop down-> apply.
Go to BYOAI URL, you can find the screen, outer border is not visible

Expected result: By providing borders to the fields.

![image](https://github.com/user-attachments/assets/21787907-1805-44be-bb24-3b0b5d4133bf)
