### PR TITLE
fix: added heading[drafts] and also added button title and label for remove icon[grants and articles]

### DIFF
--- a/App/frontend/src/components/DraftDocumentsView/DraftDocumentsView.tsx
+++ b/App/frontend/src/components/DraftDocumentsView/DraftDocumentsView.tsx
@@ -179,7 +179,7 @@ const handleCreatePDF = (): void => {
   return (
     <div className={styles.container}>
       <Stack className={styles.draftDocumentHeader}>
-        <Text variant="xLarge" className={styles.draftDocumentTitle}>Draft grant proposal</Text>
+        <h2 className={styles.draftDocumentTitle}>Draft grant proposal</h2>
         <ResearchTopicCard />
       </Stack>
 
@@ -202,7 +202,7 @@ const handleCreatePDF = (): void => {
         </div>
 
         <div>
-          <h4>Title</h4>
+          <h3>Title</h3>
           <div className={styles.titleTextfield}>
             <TextField
               placeholder="Topic"

--- a/App/frontend/src/components/SidebarView/ArticleView/ArticleView.tsx
+++ b/App/frontend/src/components/SidebarView/ArticleView/ArticleView.tsx
@@ -84,6 +84,8 @@ export const ArticleView = () => {
                     </Text>
                     
                     <Button
+                      title="remove"
+                      aria-label="remove"
                       icon={<DeleteRegular />}
                       onClick={() => handleToggleFavorite(citation)}
                       style={{

--- a/App/frontend/src/components/SidebarView/GrantView/GrantView.tsx
+++ b/App/frontend/src/components/SidebarView/GrantView/GrantView.tsx
@@ -83,6 +83,8 @@ export const GrantView = () => {
                     </Text>
                     {/* "X" button to remove the citation */}
                     <Button
+                      title="remove"
+                      aria-label="remove"
                       icon={<DeleteRegular />}
                       onClick={() => handleToggleFavorite(citation)}
                       style={{

--- a/App/frontend/src/pages/chat/Chat.tsx
+++ b/App/frontend/src/pages/chat/Chat.tsx
@@ -339,7 +339,11 @@ const Chat = ({ chatType }: Props) => {
                       color: '#72716f',
                       marginLeft: '15px',
                       marginTop: '25px',
-                      alignSelf: 'start'
+                      alignSelf: 'start',
+                      fontWeight: '600',
+                      fontFamily: '"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif',
+                      /* -webkit-font-smoothing: antialiased; */
+                      fontSize: '20px'
                     }}
                 >
                     {title}


### PR DESCRIPTION
Bug: https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/4475

**Heading**

Open BYOAI URL

Click on grants: 
Here "Explore grant documents" are not marked as heading and the heading level is like H1 and H4

Click on articles: 
Here "Explore scientific journals" are not marked as heading and the heading level is like H1 and H4

Overlapping cleaner icon so added padding

Click on Drafts
Here "Draft grant proposal" are not marked as heading and the heading level is like H1 and H4

Expected result: Need to mark as heading and Heading level should be in order H1, H2 ...... and order cannot be skipped.

Expected result: Need to mark as heading

![image](https://github.com/user-attachments/assets/3f7414f6-32c3-4b05-a350-238bf65db215)

![image](https://github.com/user-attachments/assets/b905dd57-081d-460a-8652-218ad280370a)

![image](https://github.com/user-attachments/assets/d0b9ed7f-b2f4-4ff7-9857-351b3d8ae87d)

![image](https://github.com/user-attachments/assets/bc693e2a-81f6-4619-899b-5922a4c2f257)



